### PR TITLE
Fix issue with example code where last step of tutorial fails

### DIFF
--- a/public/docs/tutorial/04-Update.md
+++ b/public/docs/tutorial/04-Update.md
@@ -6,7 +6,7 @@ Add the `mode` and `selectionChange` attributes to the list in `webapp/Tasks.vie
 ```xml
   <!-- Tasks list -->
   <List id="TaskList"
-        items="{
+          items="{
     path: '/Tasks',
     sorter: {
       path: 'createdAt',

--- a/public/docs/tutorial/04-Update.md
+++ b/public/docs/tutorial/04-Update.md
@@ -5,7 +5,8 @@ In the [previous step](/#/tutorial/mongo/step/03) we added a way for the user to
 Add the `mode` and `selectionChange` attributes to the list in `webapp/Tasks.view.xml` as follows:
 ```xml
   <!-- Tasks list -->
-  <List items="{
+  <List id="TaskList"
+        items="{
     path: '/Tasks',
     sorter: {
       path: 'createdAt',


### PR DESCRIPTION
Fix for an issue in the last step of the tutorial where this line fails because List Id is not set in XML template:

`var oTaskList = this.byId("TaskList");`
